### PR TITLE
Multilayer namespace nesting, grouping for tf and image topics, hiding for tf and dynamic reconfigure

### DIFF
--- a/resource/RosGraph.ui
+++ b/resource/RosGraph.ui
@@ -10,13 +10,13 @@
     <x>0</x>
     <y>0</y>
     <width>1298</width>
-    <height>307</height>
+    <height>369</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Node Graph</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,0,0,0">
      <item>
@@ -34,12 +34,6 @@
      </item>
      <item>
       <widget class="QComboBox" name="graph_type_combo_box">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
        <property name="toolTip">
         <string>Choose graph type</string>
        </property>
@@ -132,21 +126,37 @@
    <item>
     <widget class="QWidget" name="widget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <widget class="QWidget" name="widget" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_4a">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
          <item>
-          <widget class="QLabel">
+          <widget class="QLabel" name="label">
            <property name="text">
             <string>Group:</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QCheckBox" name="namespace_cluster_check_box">
+          <widget class="QSpinBox" name="namespace_cluster_spin_box">
            <property name="toolTip">
-            <string>Show namespace boxes</string>
+            <string>Show namespace boxes, nesting up to this amount</string>
            </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label">
            <property name="text">
             <string>Namespaces</string>
            </property>
@@ -162,6 +172,26 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QCheckBox" name="group_image_check_box">
+           <property name="toolTip">
+            <string>Summarize image topics into one virtual topic node (named &lt;image_server&gt;/image_topics)</string>
+           </property>
+           <property name="text">
+            <string>Images</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="group_tf_check_box">
+           <property name="toolTip">
+            <string>Summarize tf and tf2 topics into one virtual topic node (named /tf)</string>
+           </property>
+           <property name="text">
+            <string>tf</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -173,10 +203,74 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="highlight_connections_check_box">
+        <property name="toolTip">
+         <string>Highlight incoming and outgoing connections on mouse over</string>
+        </property>
+        <property name="text">
+         <string>Highlight</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="auto_fit_graph_check_box">
+        <property name="toolTip">
+         <string>Automatically fit graph into view on update</string>
+        </property>
+        <property name="text">
+         <string>Fit</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="fit_in_view_push_button">
+        <property name="toolTip">
+         <string>Fit graph in view</string>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
        <widget class="QWidget" name="widget" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_4b">
+        <layout class="QHBoxLayout" name="horizontalLayout_5a" stretch="0,0,0,0,0,0,0,0">
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
          <item>
-          <widget class="QLabel">
+          <widget class="QLabel" name="label">
            <property name="text">
             <string>Hide:</string>
            </property>
@@ -213,6 +307,26 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="hide_dynamic_reconfigure_check_box">
+           <property name="toolTip">
+            <string>Hide dynamic reconfigure's parameter nodes</string>
+           </property>
+           <property name="text">
+            <string>Params</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="hide_tf_nodes_check_box">
+           <property name="toolTip">
+            <string>Hide tf nodes</string>
+           </property>
+           <property name="text">
+            <string>tf</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QCheckBox" name="unreachable_check_box">
            <property name="toolTip">
             <string>Hide unreachable nodes</string>
@@ -222,67 +336,21 @@
            </property>
           </widget>
          </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
        </widget>
-      </item>
-      <item>
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="highlight_connections_check_box">
-        <property name="toolTip">
-         <string>Highlight incoming and outgoing connections on mouse over</string>
-        </property>
-        <property name="text">
-         <string>Highlight</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="auto_fit_graph_check_box">
-        <property name="toolTip">
-         <string>Automatically fit graph into view on update</string>
-        </property>
-        <property name="text">
-         <string>Fit</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="fit_in_view_push_button">
-        <property name="toolTip">
-         <string>Fit graph in view</string>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>

--- a/src/rqt_graph/ros_graph.py
+++ b/src/rqt_graph/ros_graph.py
@@ -80,7 +80,7 @@ class NamespaceCompletionModel(QAbstractListModel):
         namesset = set()
         for n in names:
             namesset.add(str(n).strip())
-            namesset.add("-%s" % (str(n).strip()))
+            namesset.add('-%s' % (str(n).strip()))
         self.names = sorted(namesset)
 
     def rowCount(self, parent):
@@ -147,12 +147,16 @@ class RosGraph(Plugin):
         self._widget.topic_filter_line_edit.editingFinished.connect(self._refresh_rosgraph)
         self._widget.topic_filter_line_edit.setCompleter(topic_completer)
 
-        self._widget.namespace_cluster_check_box.clicked.connect(self._refresh_rosgraph)
+        self._widget.namespace_cluster_spin_box.valueChanged.connect(self._refresh_rosgraph)
         self._widget.actionlib_check_box.clicked.connect(self._refresh_rosgraph)
+        self._widget.group_image_check_box.clicked.connect(self._refresh_rosgraph)
+        self._widget.group_tf_check_box.clicked.connect(self._refresh_rosgraph)
         self._widget.dead_sinks_check_box.clicked.connect(self._refresh_rosgraph)
         self._widget.leaf_topics_check_box.clicked.connect(self._refresh_rosgraph)
         self._widget.quiet_check_box.clicked.connect(self._refresh_rosgraph)
         self._widget.unreachable_check_box.clicked.connect(self._refresh_rosgraph)
+        self._widget.hide_tf_nodes_check_box.clicked.connect(self._refresh_rosgraph)
+        self._widget.hide_dynamic_reconfigure_check_box.clicked.connect(self._refresh_rosgraph)
 
         self._widget.refresh_graph_push_button.setIcon(QIcon.fromTheme('view-refresh'))
         self._widget.refresh_graph_push_button.pressed.connect(self._update_rosgraph)
@@ -181,10 +185,14 @@ class RosGraph(Plugin):
         instance_settings.set_value('graph_type_combo_box_index', self._widget.graph_type_combo_box.currentIndex())
         instance_settings.set_value('filter_line_edit_text', self._widget.filter_line_edit.text())
         instance_settings.set_value('topic_filter_line_edit_text', self._widget.topic_filter_line_edit.text())
-        instance_settings.set_value('namespace_cluster_check_box_state', self._widget.namespace_cluster_check_box.isChecked())
+        instance_settings.set_value('namespace_cluster_spin_box_value', self._widget.namespace_cluster_spin_box.value())
         instance_settings.set_value('actionlib_check_box_state', self._widget.actionlib_check_box.isChecked())
+        instance_settings.set_value('group_image_check_box_state', self._widget.group_image_check_box.isChecked())
+        instance_settings.set_value('group_tf_check_box_state', self._widget.group_tf_check_box.isChecked())
         instance_settings.set_value('dead_sinks_check_box_state', self._widget.dead_sinks_check_box.isChecked())
         instance_settings.set_value('leaf_topics_check_box_state', self._widget.leaf_topics_check_box.isChecked())
+        instance_settings.set_value('hide_dynamic_reconfigure_check_box_state', self._widget.hide_dynamic_reconfigure_check_box.isChecked())
+        instance_settings.set_value('hide_tf_nodes_check_box_state', self._widget.hide_tf_nodes_check_box.isChecked())
         instance_settings.set_value('quiet_check_box_state', self._widget.quiet_check_box.isChecked())
         instance_settings.set_value('unreachable_check_box_state', self._widget.unreachable_check_box.isChecked())
         instance_settings.set_value('auto_fit_graph_check_box_state', self._widget.auto_fit_graph_check_box.isChecked())
@@ -194,10 +202,14 @@ class RosGraph(Plugin):
         self._widget.graph_type_combo_box.setCurrentIndex(int(instance_settings.value('graph_type_combo_box_index', 0)))
         self._widget.filter_line_edit.setText(instance_settings.value('filter_line_edit_text', '/'))
         self._widget.topic_filter_line_edit.setText(instance_settings.value('topic_filter_line_edit_text', '/'))
-        self._widget.namespace_cluster_check_box.setChecked(instance_settings.value('namespace_cluster_check_box_state', True) in [True, 'true'])
+        self._widget.namespace_cluster_spin_box.setValue(int(instance_settings.value('namespace_cluster_spin_box_value', 2)))
         self._widget.actionlib_check_box.setChecked(instance_settings.value('actionlib_check_box_state', True) in [True, 'true'])
+        self._widget.group_image_check_box.setChecked(instance_settings.value('group_image_check_box_state', True) in [True, 'true'])
+        self._widget.group_tf_check_box.setChecked(instance_settings.value('group_tf_check_box_state', True) in [True, 'true'])
         self._widget.dead_sinks_check_box.setChecked(instance_settings.value('dead_sinks_check_box_state', True) in [True, 'true'])
         self._widget.leaf_topics_check_box.setChecked(instance_settings.value('leaf_topics_check_box_state', True) in [True, 'true'])
+        self._widget.hide_dynamic_reconfigure_check_box.setChecked(instance_settings.value('hide_dynamic_reconfigure_check_box_state', True) in [True, 'true'])
+        self._widget.hide_tf_nodes_check_box.setChecked(instance_settings.value('hide_tf_nodes_check_box_state', False) in [True, 'true'])
         self._widget.quiet_check_box.setChecked(instance_settings.value('quiet_check_box_state', True) in [True, 'true'])
         self._widget.unreachable_check_box.setChecked(instance_settings.value('unreachable_check_box_state', True) in [True, 'true'])
         self._widget.auto_fit_graph_check_box.setChecked(instance_settings.value('auto_fit_graph_check_box_state', True) in [True, 'true'])
@@ -210,8 +222,12 @@ class RosGraph(Plugin):
         self._widget.graph_type_combo_box.setEnabled(True)
         self._widget.filter_line_edit.setEnabled(True)
         self._widget.topic_filter_line_edit.setEnabled(True)
-        self._widget.namespace_cluster_check_box.setEnabled(True)
+        self._widget.namespace_cluster_spin_box.setEnabled(True)
         self._widget.actionlib_check_box.setEnabled(True)
+        self._widget.group_image_check_box.setEnabled(True)
+        self._widget.group_tf_check_box.setEnabled(True)
+        self._widget.hide_dynamic_reconfigure_check_box.setEnabled(True)
+        self._widget.hide_tf_nodes_check_box.setEnabled(True)
         self._widget.dead_sinks_check_box.setEnabled(True)
         self._widget.leaf_topics_check_box.setEnabled(True)
         self._widget.quiet_check_box.setEnabled(True)
@@ -235,12 +251,13 @@ class RosGraph(Plugin):
         topic_filter = self._widget.topic_filter_line_edit.text()
         graph_mode = self._widget.graph_type_combo_box.itemData(self._widget.graph_type_combo_box.currentIndex())
         orientation = 'LR'
-        if self._widget.namespace_cluster_check_box.isChecked():
-            namespace_cluster = 1
-        else:
-            namespace_cluster = 0
+        namespace_cluster = self._widget.namespace_cluster_spin_box.value()
         accumulate_actions = self._widget.actionlib_check_box.isChecked()
+        group_image_nodes = self._widget.group_image_check_box.isChecked()
+        group_tf_nodes = self._widget.group_tf_check_box.isChecked()
         hide_dead_end_topics = self._widget.dead_sinks_check_box.isChecked()
+        hide_dynamic_reconfigure = self._widget.hide_dynamic_reconfigure_check_box.isChecked()
+        hide_tf_nodes = self._widget.hide_tf_nodes_check_box.isChecked()
         hide_single_connection_topics = self._widget.leaf_topics_check_box.isChecked()
         quiet = self._widget.quiet_check_box.isChecked()
         unreachable = self._widget.unreachable_check_box.isChecked()
@@ -254,6 +271,10 @@ class RosGraph(Plugin):
             hide_dead_end_topics=hide_dead_end_topics,
             cluster_namespaces_level=namespace_cluster,
             accumulate_actions=accumulate_actions,
+            group_image_nodes=group_image_nodes,
+            group_tf_nodes=group_tf_nodes,
+            hide_dynamic_reconfigure=hide_dynamic_reconfigure,
+            hide_tf_nodes=hide_tf_nodes,
             dotcode_factory=self.dotcode_factory,
             orientation=orientation,
             quiet=quiet,
@@ -294,15 +315,11 @@ class RosGraph(Plugin):
             highlight_level = 1
 
         # layout graph and create qt items
-        (nodes, edges) = self.dot_to_qt.dotcode_to_qt_items(self._current_dotcode,
+        self.dot_to_qt.dotcode_to_qt_items(self._current_dotcode,
+                                                            scene=self._scene,
                                                             highlight_level=highlight_level,
                                                             same_label_siblings=True)
 
-        for node_item in nodes.values():
-            self._scene.addItem(node_item)
-        for edge_items in edges.values():
-            for edge_item in edge_items:
-                edge_item.add_to_scene(self._scene)
 
         self._scene.setSceneRect(self._scene.itemsBoundingRect())
         if self._widget.auto_fit_graph_check_box.isChecked():
@@ -325,8 +342,12 @@ class RosGraph(Plugin):
         self._widget.graph_type_combo_box.setEnabled(False)
         self._widget.filter_line_edit.setEnabled(False)
         self._widget.topic_filter_line_edit.setEnabled(False)
-        self._widget.namespace_cluster_check_box.setEnabled(False)
+        self._widget.namespace_cluster_spin_box.setEnabled(False)
         self._widget.actionlib_check_box.setEnabled(False)
+        self._widget.group_image_check_box.setEnabled(False)
+        self._widget.group_tf_check_box.setEnabled(False)
+        self._widget.hide_dynamic_reconfigure_check_box.setEnabled(False)
+        self._widget.hide_tf_nodes_check_box.setEnabled(False)
         self._widget.dead_sinks_check_box.setEnabled(False)
         self._widget.leaf_topics_check_box.setEnabled(False)
         self._widget.quiet_check_box.setEnabled(False)


### PR DESCRIPTION
rqt_graph has had a long-standing problem; in real use cases, graphs quickly become unwieldy and unreadable, with dynamic reconfigure's parameter topics everywhere, and don't even start with images. This large commit includes a number of feature improvements designed to combat this, listed below:

* Added nested subnamespaces; the "Group Namespaces" checkbox is now a numeric spinbox, which specifies the number of layers of depth desired.
* Allowed the grouping of tf topics (/tf and /tf_static).
* Allowed the hiding of tf topics.
* Allowed the grouping of image topics (<image>/, <image>/compressed, <image>/theora, and <image>/compressedDepth), similar to action topics.
* Allowed the hiding of dynamic reconfigure topics (<node>/parameter_descriptions and <node>/parameter_updates).
* Grouped topics (tf, action topics, and image topics) display as a 3d box when grouped.
* UI changes; reduced some margins, added checkboxes for above options, moved "Hide" section to a new line to prevent the interface being too wide.

These changes are dependent on pull request ros-visualization/qt_gui_core#87.

This pull request resolves issues ros-visualization/rqt_graph#3 and ros-visualization/rqt_graph#4.

Three files are attached to this pull request; the launch file I used for testing, a before picture, and an after picture, displaying what rqt_graph looks like before and after the changes.

![before](https://cloud.githubusercontent.com/assets/4635334/26687158/1916a570-46bd-11e7-8ca6-6978fe6e9d92.png)
![after-2](https://cloud.githubusercontent.com/assets/4635334/26687115/fba236c6-46bc-11e7-90cd-b7ac3cb73a2a.png)
[Attachments.zip](https://github.com/ros-visualization/rqt_graph/files/1045267/Attachments.zip)