### PR TITLE
Added nested subnamespaces and more options to hide or group topics.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,7 @@
 
   <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>python-rospkg</run_depend>
-  <run_depend version_gte="0.3.8">qt_dotgraph</run_depend>
+  <run_depend>qt_dotgraph</run_depend>
   <run_depend>rosgraph</run_depend>
   <run_depend>rosgraph_msgs</run_depend>
   <run_depend>roslib</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,7 @@
 
   <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>python-rospkg</run_depend>
-  <run_depend>qt_dotgraph</run_depend>
+  <run_depend version_gte="0.3.8">qt_dotgraph</run_depend>
   <run_depend>rosgraph</run_depend>
   <run_depend>rosgraph_msgs</run_depend>
   <run_depend>roslib</run_depend>

--- a/resource/RosGraph.ui
+++ b/resource/RosGraph.ui
@@ -10,13 +10,13 @@
     <x>0</x>
     <y>0</y>
     <width>1298</width>
-    <height>307</height>
+    <height>344</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Node Graph</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,0,0,0">
      <item>
@@ -132,17 +132,35 @@
    <item>
     <widget class="QWidget" name="widget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
       <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
        <widget class="QWidget" name="widget" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_4a">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
          <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel">
+          <widget class="QLabel" name="label">
            <property name="text">
             <string>Group:</string>
            </property>
@@ -157,9 +175,9 @@
          </item>
          <item>
           <widget class="QLabel" name="label">
-            <property name="text">
-              <string>Namespaces</string>
-            </property>
+           <property name="text">
+            <string>Namespaces</string>
+           </property>
           </widget>
          </item>
          <item>
@@ -260,7 +278,13 @@
    <item>
     <widget class="QWidget" name="widget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
       <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
        <number>0</number>
       </property>
       <property name="bottomMargin">
@@ -269,11 +293,20 @@
       <item>
        <widget class="QWidget" name="widget" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_5a" stretch="0,0,0,0,0,0,0,0">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
          <property name="topMargin">
           <number>0</number>
          </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
          <item>
-          <widget class="QLabel">
+          <widget class="QLabel" name="label">
            <property name="text">
             <string>Hide:</string>
            </property>
@@ -352,7 +385,7 @@
            </property>
           </spacer>
          </item>
-       </layout>
+        </layout>
        </widget>
       </item>
      </layout>

--- a/resource/RosGraph.ui
+++ b/resource/RosGraph.ui
@@ -132,9 +132,15 @@
    <item>
     <widget class="QWidget" name="widget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <widget class="QWidget" name="widget" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_4a">
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
          <item>
           <widget class="QLabel">
            <property name="text">
@@ -163,66 +169,6 @@
            </property>
            <property name="text">
             <string>Actions</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QWidget" name="widget" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_4b">
-         <item>
-          <widget class="QLabel">
-           <property name="text">
-            <string>Hide:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="dead_sinks_check_box">
-           <property name="toolTip">
-            <string>Hide topics without subscribers</string>
-           </property>
-           <property name="text">
-            <string>Dead sinks</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="leaf_topics_check_box">
-           <property name="toolTip">
-            <string>Hide topics with one connection only (implicates dead sinks)</string>
-           </property>
-           <property name="text">
-            <string>Leaf topics</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="quiet_check_box">
-           <property name="toolTip">
-            <string>Hide common debugging nodes</string>
-           </property>
-           <property name="text">
-            <string>Debug</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="unreachable_check_box">
-           <property name="toolTip">
-            <string>Hide unreachable nodes</string>
-           </property>
-           <property name="text">
-            <string>Unreachable</string>
            </property>
           </widget>
          </item>
@@ -287,6 +233,87 @@
          </size>
         </property>
        </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QWidget" name="widget" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_5a" stretch="0,0,0,0,0,0,0,0">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel">
+           <property name="text">
+            <string>Hide:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="dead_sinks_check_box">
+           <property name="toolTip">
+            <string>Hide topics without subscribers</string>
+           </property>
+           <property name="text">
+            <string>Dead sinks</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="leaf_topics_check_box">
+           <property name="toolTip">
+            <string>Hide topics with one connection only (implicates dead sinks)</string>
+           </property>
+           <property name="text">
+            <string>Leaf topics</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="quiet_check_box">
+           <property name="toolTip">
+            <string>Hide common debugging nodes</string>
+           </property>
+           <property name="text">
+            <string>Debug</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="unreachable_check_box">
+           <property name="toolTip">
+            <string>Hide unreachable nodes</string>
+           </property>
+           <property name="text">
+            <string>Unreachable</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+       </layout>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/resource/RosGraph.ui
+++ b/resource/RosGraph.ui
@@ -182,6 +182,16 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QCheckBox" name="group_image_check_box">
+           <property name="toolTip">
+            <string>Summarize image topics into one virtual topic node (named &lt;image_server&gt;/image_topics)</string>
+           </property>
+           <property name="text">
+            <string>Images</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>

--- a/resource/RosGraph.ui
+++ b/resource/RosGraph.ui
@@ -172,6 +172,16 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QCheckBox" name="group_tf_check_box">
+           <property name="toolTip">
+            <string>Summarize tf and tf2 topics into one virtual topic node (named /tf)</string>
+           </property>
+           <property name="text">
+            <string>tf</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -286,6 +296,16 @@
            </property>
            <property name="text">
             <string>Debug</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="hide_tf_nodes_check_box">
+           <property name="toolTip">
+            <string>Hide tf nodes</string>
+           </property>
+           <property name="text">
+            <string>tf</string>
            </property>
           </widget>
          </item>

--- a/resource/RosGraph.ui
+++ b/resource/RosGraph.ui
@@ -143,13 +143,17 @@
           </widget>
          </item>
          <item>
-          <widget class="QCheckBox" name="namespace_cluster_check_box">
+          <widget class="QSpinBox" name="namespace_cluster_spin_box">
            <property name="toolTip">
-            <string>Show namespace boxes</string>
+            <string>Show namespace boxes, nesting up to this amount</string>
            </property>
-           <property name="text">
-            <string>Namespaces</string>
-           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label">
+            <property name="text">
+              <string>Namespaces</string>
+            </property>
           </widget>
          </item>
          <item>

--- a/resource/RosGraph.ui
+++ b/resource/RosGraph.ui
@@ -330,6 +330,16 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="hide_dynamic_reconfigure_check_box">
+           <property name="toolTip">
+            <string>Hide dynamic reconfigure's parameter topics</string>
+           </property>
+           <property name="text">
+            <string>Params</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="horizontalSpacer_3">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/src/rqt_graph/dotcode.py
+++ b/src/rqt_graph/dotcode.py
@@ -49,7 +49,9 @@ NODE_TOPIC_GRAPH = 'node_topic'
 # all node/topic connections, even if no actual network connection
 NODE_TOPIC_ALL_GRAPH = 'node_topic_all'
 
-QUIET_NAMES = ['/diag_agg', '/runtime_logger', '/pr2_dashboard', '/rviz', '/rosout', '/cpu_monitor', '/monitor', '/hd_monitor', '/rxloggerlevel', '/clock', '/rqt', '/statistics']
+QUIET_NAMES = ['/diag_agg', '/runtime_logger', '/pr2_dashboard', '/rviz',
+               '/rosout', '/cpu_monitor', '/monitor', '/hd_monitor',
+               '/rxloggerlevel', '/clock', '/rqt', '/statistics']
 
 def _conv(n):
     """Convert a node name to a valid dot name, which can't contain the leading space"""
@@ -176,7 +178,7 @@ class RosGraphDotcodeGenerator:
             else:
                 penwidth = self._calc_edge_penwidth(sub,topic)
                 color = self._calc_edge_color(sub,topic)
-                label = "("+str(conns) + " connections)"
+                label = "(" + str(conns) + " connections)"
                 return [label, penwidth, color]
 
         if sub in self.edges and topic in self.edges[sub] and pub in self.edges[sub][topic]:
@@ -204,16 +206,34 @@ class RosGraphDotcodeGenerator:
             [stat_label, penwidth, color] = self._calc_statistic_info(sub, topic, pub)
             if stat_label is not None:
                 temp_label = edge.label + "\\n" + stat_label
-                dotcode_factory.add_edge_to_graph(dotgraph, _conv(edge.start), _conv(edge.end), label=temp_label, url='topic:%s' % edge.label, penwidth=penwidth, color=color)
+                dotcode_factory.add_edge_to_graph(
+                    dotgraph,
+                    _conv(edge.start),
+                    _conv(edge.end),
+                    label=temp_label,
+                    url='topic:%s' % edge.label,
+                    penwidth=penwidth,
+                    color=color)
             else:
-                dotcode_factory.add_edge_to_graph(dotgraph, _conv(edge.start), _conv(edge.end), label=edge.label, url='topic:%s' % edge.label)
+                dotcode_factory.add_edge_to_graph(
+                    dotgraph,
+                    _conv(edge.start),
+                    _conv(edge.end),
+                    label=edge.label,
+                    url='topic:%s' % edge.label)
         else:
             sub = edge.end.strip()
             topic = edge.start.strip()
             [stat_label, penwidth, color] = self._calc_statistic_info(sub, topic)
             if stat_label is not None:
                 temp_label = edge.label + "\\n" + stat_label
-                dotcode_factory.add_edge_to_graph(dotgraph, _conv(edge.start), _conv(edge.end), label=temp_label, penwidth=penwidth, color=color)
+                dotcode_factory.add_edge_to_graph(
+                    dotgraph,
+                    _conv(edge.start),
+                    _conv(edge.end),
+                    label=temp_label,
+                    penwidth=penwidth,
+                    color=color)
             else:
                 dotcode_factory.add_edge_to_graph(dotgraph, _conv(edge.start), _conv(edge.end), label=edge.label)
 
@@ -224,48 +244,54 @@ class RosGraphDotcodeGenerator:
                 return ''
             bn = rosgraphinst.bad_nodes[node]
             if bn.type == rosgraph.impl.graph.BadNode.DEAD:
-                dotcode_factory.add_node_to_graph(dotgraph,
-                                                  nodename=_conv(node),
-                                                  nodelabel=node,
-                                                  shape="ellipse",
-                                                  url=node + " (DEAD)",
-                                                  color="red")
+                dotcode_factory.add_node_to_graph(
+                    dotgraph,
+                    nodename=_conv(node),
+                    nodelabel=node,
+                    shape="ellipse",
+                    url=node + " (DEAD)",
+                    color="red")
             elif bn.type == rosgraph.impl.graph.BadNode.WONKY:
-                dotcode_factory.add_node_to_graph(dotgraph,
-                                                  nodename=_conv(node),
-                                                  nodelabel=node,
-                                                  shape="ellipse",
-                                                  url=node + " (WONKY)",
-                                                  color="orange")
+                dotcode_factory.add_node_to_graph(
+                    dotgraph,
+                    nodename=_conv(node),
+                    nodelabel=node,
+                    shape="ellipse",
+                    url=node + " (WONKY)",
+                    color="orange")
             else:
-                dotcode_factory.add_node_to_graph(dotgraph,
-                                                  nodename=_conv(node),
-                                                  nodelabel=node,
-                                                  shape="ellipse",
-                                                  url=node + " (UNKNOWN)",
-                                                  color="red")
+                dotcode_factory.add_node_to_graph(
+                    dotgraph,
+                    nodename=_conv(node),
+                    nodelabel=node,
+                    shape="ellipse",
+                    url=node + " (UNKNOWN)",
+                    color="red")
         else:
-            dotcode_factory.add_node_to_graph(dotgraph,
-                                              nodename=_conv(node),
-                                              nodelabel=node,
-                                              shape='ellipse',
-                                              url=node)
+            dotcode_factory.add_node_to_graph(
+                dotgraph,
+                nodename=_conv(node),
+                nodelabel=node,
+                shape='ellipse',
+                url=node)
 
     def _add_topic_node(self, node, dotcode_factory, dotgraph, quiet):
         label = rosgraph.impl.graph.node_topic(node)
-        dotcode_factory.add_node_to_graph(dotgraph,
-                                          nodename=_conv(node),
-                                          nodelabel=label,
-                                          shape='box',
-                                          url="topic:%s" % label)
+        dotcode_factory.add_node_to_graph(
+            dotgraph,
+            nodename=_conv(node),
+            nodelabel=label,
+            shape='box',
+            url="topic:%s" % label)
 
     def _add_topic_node_group(self, node, dotcode_factory, dotgraph, quiet):
         label = rosgraph.impl.graph.node_topic(node)
-        dotcode_factory.add_node_to_graph(dotgraph,
-                                          nodename=_conv(node),
-                                          nodelabel=label,
-                                          shape='box3d',
-                                          url='topic:%s' % label)
+        dotcode_factory.add_node_to_graph(
+            dotgraph,
+            nodename=_conv(node),
+            nodelabel=label,
+            shape='box3d',
+            url='topic:%s' % label)
 
     def _quiet_filter(self, name):
         # ignore viewers
@@ -292,7 +318,7 @@ class RosGraphDotcodeGenerator:
             namespaces = list(set([roslib.names.namespace(n) for n in nodes]))
 
         elif graph_mode == NODE_TOPIC_GRAPH or \
-                 graph_mode == NODE_TOPIC_ALL_GRAPH:
+                graph_mode == NODE_TOPIC_ALL_GRAPH:
             nn_nodes = graph.nn_nodes
             nt_nodes = graph.nt_nodes
             if quiet:
@@ -318,7 +344,7 @@ class RosGraphDotcodeGenerator:
         for n in nt_nodes:
             keep = False
             for e in edges:
-                if (e.start.strip() == str(n).strip() or e.end.strip() == str(n).strip()):
+                if e.start.strip() == str(n).strip() or e.end.strip() == str(n).strip():
                     keep = True
                     break
             if not keep:
@@ -353,12 +379,13 @@ class RosGraphDotcodeGenerator:
             node_connections[edge.end].incoming.append(edge)
         return node_connections
 
-    def _filter_leaf_topics(self,
-                            nodes_in,
-                            edges_in,
-                            node_connections,
-                            hide_single_connection_topics,
-                            hide_dead_end_topics):
+    def _filter_leaf_topics(
+        self,
+        nodes_in,
+        edges_in,
+        node_connections,
+        hide_single_connection_topics,
+        hide_dead_end_topics):
         '''
         removes certain ending topic nodes and their edges from list of nodes and edges
 
@@ -379,8 +406,8 @@ class RosGraphDotcodeGenerator:
                 if len(node_connections[n].outgoing) > 0:
                     has_out_edges = True
                 node_edges.extend(node_connections[n].incoming)
-                if ((hide_single_connection_topics and len(node_edges) < 2) or
-                    (hide_dead_end_topics and not has_out_edges)):
+                if (hide_single_connection_topics and len(node_edges) < 2) or \
+                    (hide_dead_end_topics and not has_out_edges):
                     removal_nodes.append(n)
                     for e in node_edges:
                         if e in edges:
@@ -428,23 +455,46 @@ class RosGraphDotcodeGenerator:
             nodes.remove(n)
         return nodes, edges, action_nodes
 
-    def _populate_node_graph(self, cluster_namespaces_level, node_list, dotcode_factory, dotgraph, rank, orientation, simplify):
+    def _populate_node_graph(
+        self, 
+        cluster_namespaces_level, 
+        node_list, 
+        dotcode_factory, 
+        dotgraph, 
+        rank, 
+        orientation, 
+        simplify):
         namespace_clusters = {}
-        if (cluster_namespaces_level > 0):
+        if cluster_namespaces_level > 0:
             for node in node_list:
-                if (str(node.strip()).count('/') > 2):
-                    for i in range(2, min(2+cluster_namespaces_level, len(node.strip().split('/')))):
+                if str(node.strip()).count('/') > 2:
+                    for i in range(2, min(2 + cluster_namespaces_level, len(node.strip().split('/')))):
                         namespace = '/'.join(node.strip().split('/')[:i])
-                        parent_namespace = '/'.join(node.strip().split('/')[:i-1])
+                        parent_namespace = '/'.join(node.strip().split('/')[:i - 1])
                         if namespace not in namespace_clusters:
                             if parent_namespace == '':
-                                namespace_clusters[namespace] = dotcode_factory.add_subgraph_to_graph(dotgraph, namespace, rank=rank, rankdir=orientation, simplify=simplify)        
+                                namespace_clusters[namespace] = dotcode_factory.add_subgraph_to_graph(
+                                    dotgraph,
+                                    namespace,
+                                    rank=rank,
+                                    rankdir=orientation,
+                                    simplify=simplify)
                             elif parent_namespace in namespace_clusters:
-                                namespace_clusters[namespace] = dotcode_factory.add_subgraph_to_graph(namespace_clusters[parent_namespace], namespace, rank=rank, rankdir=orientation, simplify=simplify)
-                elif (str(node.strip()).count('/') == 2):
+                                namespace_clusters[namespace] = dotcode_factory.add_subgraph_to_graph(
+                                    namespace_clusters[parent_namespace],
+                                    namespace,
+                                    rank=rank,
+                                    rankdir=orientation,
+                                    simplify=simplify)
+                elif str(node.strip()).count('/') == 2:
                     namespace = '/'.join(node.strip().split('/')[0:2])
                     if namespace not in namespace_clusters:
-                        namespace_clusters[namespace] = dotcode_factory.add_subgraph_to_graph(dotgraph, namespace, rank=rank, rankdir=orientation, simplify=simplify)
+                        namespace_clusters[namespace] = dotcode_factory.add_subgraph_to_graph(
+                            dotgraph,
+                            namespace,
+                            rank=rank,
+                            rankdir=orientation,
+                            simplify=simplify)
         return namespace_clusters
 
     def _group_tf_nodes(self, nodes_in, edges_in, node_connections):
@@ -453,7 +503,6 @@ class RosGraphDotcodeGenerator:
         edges where the edges to tf topics have been removed, and
         a map with all the connections to the resulting tf group node'''
         removal_nodes = []
-        tf_nodes = {}
         tf_topic_edges_in = set()
         tf_topic_edges_out = set()
         # do not manipulate incoming structures
@@ -474,7 +523,7 @@ class RosGraphDotcodeGenerator:
         for n in removal_nodes:
             if n in nodes:
                 nodes.remove(n)
-        if len(tf_topic_edges_in) == 0 and len(tf_topic_edges_out) == 0:
+        if not tf_topic_edges_in and not tf_topic_edges_out:
             return nodes, edges, None
 
         return nodes, edges, {'outgoing': tf_topic_edges_out, 'incoming': tf_topic_edges_in}
@@ -518,12 +567,13 @@ class RosGraphDotcodeGenerator:
             nodes.remove(n)
         return nodes, edges, image_nodes
 
-    def _filter_hidden_topics(self,
-                              nodes_in,
-                              edges_in,
-                              node_connections,
-                              hide_tf_nodes,
-                              hide_dynamic_reconfigure):
+    def _filter_hidden_topics(
+        self,
+        nodes_in,
+        edges_in,
+        node_connections,
+        hide_tf_nodes,
+        hide_dynamic_reconfigure):
         if not hide_tf_nodes and not hide_dynamic_reconfigure:
             return nodes_in, edges_in
         # do not manipulate incoming structures
@@ -558,27 +608,28 @@ class RosGraphDotcodeGenerator:
                 nodes.remove(n)
         return nodes, edges
 
-    def generate_dotgraph(self,
-                         rosgraphinst,
-                         ns_filter,
-                         topic_filter,
-                         graph_mode,
-                         dotcode_factory,
-                         hide_single_connection_topics=False,
-                         hide_dead_end_topics=False,
-                         cluster_namespaces_level=0,
-                         accumulate_actions=True,
-                         orientation='LR',
-                         rank='same',  # None, same, min, max, source, sink
-                         ranksep=0.2,  # vertical distance between layers
-                         rankdir='TB',  # direction of layout (TB top > bottom, LR left > right)
-                         simplify=True,  # remove double edges
-                         quiet=False,
-                         unreachable=False,
-                         group_tf_nodes=False,
-                         hide_tf_nodes=False,
-                         group_image_nodes=False,
-                         hide_dynamic_reconfigure=False):
+    def generate_dotgraph(
+        self,
+        rosgraphinst,
+        ns_filter,
+        topic_filter,
+        graph_mode,
+        dotcode_factory,
+        hide_single_connection_topics=False,
+        hide_dead_end_topics=False,
+        cluster_namespaces_level=0,
+        accumulate_actions=True,
+        orientation='LR',
+        rank='same',  # None, same, min, max, source, sink
+        ranksep=0.2,  # vertical distance between layers
+        rankdir='TB',  # direction of layout (TB top > bottom, LR left > right)
+        simplify=True,  # remove double edges
+        quiet=False,
+        unreachable=False,
+        group_tf_nodes=False,
+        hide_tf_nodes=False,
+        group_image_nodes=False,
+        hide_dynamic_reconfigure=False):
         """
         See generate_dotcode
         """
@@ -620,21 +671,26 @@ class RosGraphDotcodeGenerator:
         # for accumulating tf node connections
         tf_connections = None
 
-        if graph_mode != NODE_NODE_GRAPH and (hide_single_connection_topics or hide_dead_end_topics or accumulate_actions or group_tf_nodes or hide_tf_nodes or group_image_nodes or hide_dynamic_reconfigure):
+        if graph_mode != NODE_NODE_GRAPH and (hide_single_connection_topics \
+                or hide_dead_end_topics or accumulate_actions
+                or group_tf_nodes or hide_tf_nodes
+                or group_image_nodes or hide_dynamic_reconfigure):
             # maps outgoing and incoming edges to nodes
             node_connections = self._get_node_edge_map(edges)
 
-            nt_nodes, edges = self._filter_leaf_topics(nt_nodes,
-                                        edges,
-                                        node_connections,
-                                        hide_single_connection_topics,
-                                        hide_dead_end_topics)
+            nt_nodes, edges = self._filter_leaf_topics(
+                nt_nodes,
+                edges,
+                node_connections,
+                hide_single_connection_topics,
+                hide_dead_end_topics)
 
-            nt_nodes, edges = self._filter_hidden_topics(nt_nodes,
-                                        edges,
-                                        node_connections,
-                                        hide_tf_nodes,
-                                        hide_dynamic_reconfigure)
+            nt_nodes, edges = self._filter_hidden_topics(
+                nt_nodes,
+                edges,
+                node_connections,
+                hide_tf_nodes,
+                hide_dynamic_reconfigure)
 
             if accumulate_actions:
                 nt_nodes, edges, action_nodes = self._accumulate_action_topics(nt_nodes, edges, node_connections)
@@ -648,64 +704,53 @@ class RosGraphDotcodeGenerator:
 
         # create the graph
         # result = "digraph G {\n  rankdir=%(orientation)s;\n%(nodes_str)s\n%(edges_str)s}\n" % vars()
-        dotgraph = dotcode_factory.get_graph(rank=rank,
-                                             ranksep=ranksep,
-                                             simplify=simplify,
-                                             rankdir=orientation)
+        dotgraph = dotcode_factory.get_graph(
+            rank=rank,
+            ranksep=ranksep,
+            simplify=simplify,
+            rankdir=orientation)
 
         ACTION_TOPICS_SUFFIX = '/action_topics'
         IMAGE_TOPICS_SUFFIX = '/image_topics'
 
-        namespace_clusters = self._populate_node_graph(cluster_namespaces_level, (nt_nodes or [])
-                                    + [action_prefix + ACTION_TOPICS_SUFFIX for (action_prefix, _) in action_nodes.items()]
-                                    + [image_prefix + IMAGE_TOPICS_SUFFIX for (image_prefix, _) in image_nodes.items()]
-                                    + nn_nodes if nn_nodes is not None else [],
-                                    dotcode_factory, dotgraph, rank, orientation, simplify)
+        namespace_clusters = self._populate_node_graph(
+            cluster_namespaces_level,
+            (nt_nodes or [])
+                + [action_prefix + ACTION_TOPICS_SUFFIX for (action_prefix, _) in action_nodes.items()]
+                + [image_prefix + IMAGE_TOPICS_SUFFIX for (image_prefix, _) in image_nodes.items()]
+                + nn_nodes if nn_nodes is not None else [],
+            dotcode_factory,
+            dotgraph,
+            rank,
+            orientation,
+            simplify)
 
         for n in nt_nodes or []:
              # cluster topics with same namespace
-             if (cluster_namespaces_level > 0 and
-                n.strip().count('/') > 1 and
-                len(n.strip().split('/')[1]) > 0):
-                if (n.count('/') <= cluster_namespaces_level):
+             if cluster_namespaces_level > 0 and \
+                    str(n).strip().count('/') > 1 and \
+                    len(n.strip().split('/')[1]) > 0:
+                if n.count('/') <= cluster_namespaces_level:
                     namespace = str('/'.join(n.strip().split('/')[:-1]))
                 else:
-                    namespace = '/'.join(n.strip().split('/')[:cluster_namespaces_level+1])
-                if namespace not in namespace_clusters:
-                    print("Namespace '"+namespace+"' not found.")
+                    namespace = '/'.join(n.strip().split('/')[:cluster_namespaces_level + 1])
                 self._add_topic_node(n, dotcode_factory=dotcode_factory, dotgraph=namespace_clusters[namespace], quiet=quiet)
              else:
                 self._add_topic_node(n, dotcode_factory=dotcode_factory, dotgraph=dotgraph, quiet=quiet)
 
-        for n in [action_prefix + ACTION_TOPICS_SUFFIX for (action_prefix, _) in action_nodes.items()]:
+        for n in [action_prefix + ACTION_TOPICS_SUFFIX for (action_prefix, _) in action_nodes.items()] + \
+                [image_prefix + IMAGE_TOPICS_SUFFIX for (image_prefix, _) in image_nodes.items()]:
             # cluster topics with same namespace
-            if (cluster_namespaces_level > 0 and
-                str(n).strip().count('/') > 1 and
-                len(str(n).strip().split('/')[1]) > 0):
-                if (n.strip().count('/') <= cluster_namespaces_level):
+            if cluster_namespaces_level > 0 and \
+                    str(n).strip().count('/') > 1 and \
+                    len(str(n).strip().split('/')[1]) > 0:
+                if n.strip().count('/') <= cluster_namespaces_level:
                     namespace = str('/'.join(n.strip().split('/')[:-1]))
                 else:
-                    namespace = '/'.join(n.strip().split('/')[:cluster_namespaces_level+1])
-                if namespace not in namespace_clusters:
-                    print("Namespace '"+namespace+"' not found.")
-                self._add_topic_node_group('n'+n, dotcode_factory=dotcode_factory, dotgraph=namespace_clusters[namespace], quiet=quiet)
+                    namespace = '/'.join(n.strip().split('/')[:cluster_namespaces_level + 1])
+                self._add_topic_node_group('n' + n, dotcode_factory=dotcode_factory, dotgraph=namespace_clusters[namespace], quiet=quiet)
             else:
-                self._add_topic_node_group('n'+n, dotcode_factory=dotcode_factory, dotgraph=dotgraph, quiet=quiet)
-
-        for n in [image_prefix + IMAGE_TOPICS_SUFFIX for (image_prefix, _) in image_nodes.items()]:
-            # cluster topics with same namespace
-            if (cluster_namespaces_level > 0 and
-                str(n).strip().count('/') > 1 and
-                len(str(n).strip().split('/')[1]) > 0):
-                if (n.strip().count('/') <= cluster_namespaces_level):
-                    namespace = str('/'.join(n.strip().split('/')[:-1]))
-                else:
-                    namespace = '/'.join(n.strip().split('/')[:cluster_namespaces_level+1])
-                if namespace not in namespace_clusters:
-                    print("Namespace '"+namespace+"' not found.")
-                self._add_topic_node_group('n'+n, dotcode_factory=dotcode_factory, dotgraph=namespace_clusters[namespace], quiet=quiet)
-            else:
-                self._add_topic_node_group('n'+n, dotcode_factory=dotcode_factory, dotgraph=dotgraph, quiet=quiet)
+                self._add_topic_node_group('n' + n, dotcode_factory=dotcode_factory, dotgraph=dotgraph, quiet=quiet)
 
         if tf_connections != None:
             # render tf nodes as a single node
@@ -718,57 +763,78 @@ class RosGraphDotcodeGenerator:
         # for ROS node, if we have created a namespace clusters for
         # one of its peer topics, drop it into that cluster
         for n in nn_nodes or []:
-            if (cluster_namespaces_level > 0 and
-                n.strip().count('/') > 1 and
-                len(n.strip().split('/')[1]) > 0):
-                if (n.count('/') <= cluster_namespaces_level):
+            if cluster_namespaces_level > 0 and \
+                    n.strip().count('/') > 1 and \
+                    len(n.strip().split('/')[1]) > 0:
+                if n.count('/') <= cluster_namespaces_level:
                     namespace = str('/'.join(n.strip().split('/')[:-1]))
                 else:
-                    namespace = '/'.join(n.strip().split('/')[:cluster_namespaces_level+1])
-                if namespace not in namespace_clusters:
-                    print("Namespace '"+namespace+"' not found.")
-                self._add_node(n, rosgraphinst=rosgraphinst, dotcode_factory=dotcode_factory, dotgraph=namespace_clusters[namespace], unreachable=unreachable)
+                    namespace = '/'.join(n.strip().split('/')[:cluster_namespaces_level + 1])
+                self._add_node(
+                    n,
+                    rosgraphinst=rosgraphinst,
+                    dotcode_factory=dotcode_factory,
+                    dotgraph=namespace_clusters[namespace],
+                    unreachable=unreachable)
             else:
-                self._add_node(n, rosgraphinst=rosgraphinst, dotcode_factory=dotcode_factory, dotgraph=dotgraph, unreachable=unreachable)
+                self._add_node(
+                    n,
+                    rosgraphinst=rosgraphinst,
+                    dotcode_factory=dotcode_factory,
+                    dotgraph=dotgraph,
+                    unreachable=unreachable)
 
         for e in edges:
             self._add_edge(e, dotcode_factory, dotgraph=dotgraph, is_topic=(graph_mode == NODE_NODE_GRAPH))
 
         for (action_prefix, node_connections) in action_nodes.items():
             for out_edge in node_connections.get('outgoing', []):
-                dotcode_factory.add_edge_to_graph(dotgraph, _conv('n'+action_prefix + ACTION_TOPICS_SUFFIX), _conv(out_edge.end))
+                dotcode_factory.add_edge_to_graph(
+                    dotgraph,
+                    _conv('n' + action_prefix + ACTION_TOPICS_SUFFIX),
+                    _conv(out_edge.end))
             for in_edge in node_connections.get('incoming', []):
-                dotcode_factory.add_edge_to_graph(dotgraph, _conv(in_edge.start), _conv('n'+action_prefix + ACTION_TOPICS_SUFFIX))
+                dotcode_factory.add_edge_to_graph(
+                    dotgraph,
+                    _conv(in_edge.start),
+                    _conv('n' + action_prefix + ACTION_TOPICS_SUFFIX))
         for (image_prefix, node_connections) in image_nodes.items():
             for out_edge in node_connections.get('outgoing', []):
-                dotcode_factory.add_edge_to_graph(dotgraph, _conv('n'+image_prefix + IMAGE_TOPICS_SUFFIX), _conv(out_edge.end))
+                dotcode_factory.add_edge_to_graph(
+                    dotgraph,
+                    _conv('n' + image_prefix + IMAGE_TOPICS_SUFFIX),
+                    _conv(out_edge.end))
             for in_edge in node_connections.get('incoming', []):
-                dotcode_factory.add_edge_to_graph(dotgraph, _conv(in_edge.start), _conv('n'+image_prefix + IMAGE_TOPICS_SUFFIX))
+                dotcode_factory.add_edge_to_graph(
+                    dotgraph,
+                    _conv(in_edge.start),
+                    _conv('n' + image_prefix + IMAGE_TOPICS_SUFFIX))
 
 
         return dotgraph
 
-    def generate_dotcode(self,
-                         rosgraphinst,
-                         ns_filter,
-                         topic_filter,
-                         graph_mode,
-                         dotcode_factory,
-                         hide_single_connection_topics=False,
-                         hide_dead_end_topics=False,
-                         cluster_namespaces_level=0,
-                         accumulate_actions=True,
-                         orientation='LR',
-                         rank='same',  # None, same, min, max, source, sink
-                         ranksep=0.2,  # vertical distance between layers
-                         rankdir='TB',  # direction of layout (TB top > bottom, LR left > right)
-                         simplify=True,  # remove double edges
-                         quiet=False,
-                         unreachable=False,
-                         hide_tf_nodes=False,
-                         group_tf_nodes=False,
-                         group_image_nodes=False,
-                         hide_dynamic_reconfigure=False):
+    def generate_dotcode(
+        self,
+        rosgraphinst,
+        ns_filter,
+        topic_filter,
+        graph_mode,
+        dotcode_factory,
+        hide_single_connection_topics=False,
+        hide_dead_end_topics=False,
+        cluster_namespaces_level=0,
+        accumulate_actions=True,
+        orientation='LR',
+        rank='same',  # None, same, min, max, source, sink
+        ranksep=0.2,  # vertical distance between layers
+        rankdir='TB',  # direction of layout (TB top > bottom, LR left > right)
+        simplify=True,  # remove double edges
+        quiet=False,
+        unreachable=False,
+        hide_tf_nodes=False,
+        group_tf_nodes=False,
+        group_image_nodes=False,
+        hide_dynamic_reconfigure=False):
         """
         @param rosgraphinst: RosGraph instance
         @param ns_filter: nodename filter
@@ -787,25 +853,26 @@ class RosGraphDotcodeGenerator:
         @return: dotcode generated from graph singleton
         @rtype: str
         """
-        dotgraph = self.generate_dotgraph(rosgraphinst=rosgraphinst,
-                         ns_filter=ns_filter,
-                         topic_filter=topic_filter,
-                         graph_mode=graph_mode,
-                         dotcode_factory=dotcode_factory,
-                         hide_single_connection_topics=hide_single_connection_topics,
-                         hide_dead_end_topics=hide_dead_end_topics,
-                         cluster_namespaces_level=cluster_namespaces_level,
-                         accumulate_actions=accumulate_actions,
-                         orientation=orientation,
-                         rank=rank,
-                         ranksep=ranksep,
-                         rankdir=rankdir,
-                         simplify=simplify,
-                         quiet=quiet,
-                         unreachable=unreachable,
-                         hide_tf_nodes=hide_tf_nodes,
-                         group_tf_nodes=group_tf_nodes,
-                         group_image_nodes=group_image_nodes,
-                         hide_dynamic_reconfigure=hide_dynamic_reconfigure)
+        dotgraph = self.generate_dotgraph(
+            rosgraphinst=rosgraphinst,
+            ns_filter=ns_filter,
+            topic_filter=topic_filter,
+            graph_mode=graph_mode,
+            dotcode_factory=dotcode_factory,
+            hide_single_connection_topics=hide_single_connection_topics,
+            hide_dead_end_topics=hide_dead_end_topics,
+            cluster_namespaces_level=cluster_namespaces_level,
+            accumulate_actions=accumulate_actions,
+            orientation=orientation,
+            rank=rank,
+            ranksep=ranksep,
+            rankdir=rankdir,
+            simplify=simplify,
+            quiet=quiet,
+            unreachable=unreachable,
+            hide_tf_nodes=hide_tf_nodes,
+            group_tf_nodes=group_tf_nodes,
+            group_image_nodes=group_image_nodes,
+            hide_dynamic_reconfigure=hide_dynamic_reconfigure)
         dotcode = dotcode_factory.create_dot(dotgraph)
         return dotcode

--- a/src/rqt_graph/ros_graph.py
+++ b/src/rqt_graph/ros_graph.py
@@ -155,6 +155,7 @@ class RosGraph(Plugin):
         self._widget.unreachable_check_box.clicked.connect(self._refresh_rosgraph)
         self._widget.group_tf_check_box.clicked.connect(self._refresh_rosgraph)
         self._widget.hide_tf_nodes_check_box.clicked.connect(self._refresh_rosgraph)
+        self._widget.group_image_check_box.clicked.connect(self._refresh_rosgraph)
 
         self._widget.refresh_graph_push_button.setIcon(QIcon.fromTheme('view-refresh'))
         self._widget.refresh_graph_push_button.pressed.connect(self._update_rosgraph)
@@ -193,6 +194,7 @@ class RosGraph(Plugin):
         instance_settings.set_value('highlight_connections_check_box_state', self._widget.highlight_connections_check_box.isChecked())
         instance_settings.set_value('group_tf_check_box_state', self._widget.group_tf_check_box.isChecked())
         instance_settings.set_value('hide_tf_nodes_check_box_state', self._widget.hide_tf_nodes_check_box.isChecked())
+        instance_settings.set_value('group_image_check_box_state', self._widget.group_image_check_box.isChecked())
 
     def restore_settings(self, plugin_settings, instance_settings):
         self._widget.graph_type_combo_box.setCurrentIndex(int(instance_settings.value('graph_type_combo_box_index', 0)))
@@ -208,6 +210,7 @@ class RosGraph(Plugin):
         self._widget.highlight_connections_check_box.setChecked(instance_settings.value('highlight_connections_check_box_state', True) in [True, 'true'])
         self._widget.hide_tf_nodes_check_box.setChecked(instance_settings.value('hide_tf_nodes_check_box_state', False) in [True, 'true'])
         self._widget.group_tf_check_box.setChecked(instance_settings.value('group_tf_check_box_state', True) in [True, 'true'])
+        self._widget.group_image_check_box.setChecked(instance_settings.value('group_image_check_box_state', True) in [True, 'true'])
         self.initialized = True
         self._refresh_rosgraph()
 
@@ -224,6 +227,7 @@ class RosGraph(Plugin):
         self._widget.unreachable_check_box.setEnabled(True)
         self._widget.group_tf_check_box.setEnabled(True)
         self._widget.hide_tf_nodes_check_box.setEnabled(True)
+        self._widget.group_image_check_box.setEnabled(True)
 
         self._graph = rosgraph.impl.graph.Graph()
         self._graph.set_master_stale(5.0)
@@ -251,6 +255,7 @@ class RosGraph(Plugin):
         unreachable = self._widget.unreachable_check_box.isChecked()
         group_tf_nodes = self._widget.group_tf_check_box.isChecked()
         hide_tf_nodes = self._widget.hide_tf_nodes_check_box.isChecked()
+        group_image_nodes = self._widget.group_image_check_box.isChecked()
 
         return self.dotcode_generator.generate_dotcode(
             rosgraphinst=self._graph,
@@ -266,7 +271,8 @@ class RosGraph(Plugin):
             quiet=quiet,
             unreachable=unreachable,
             group_tf_nodes=group_tf_nodes,
-            hide_tf_nodes=hide_tf_nodes)
+            hide_tf_nodes=hide_tf_nodes,
+            group_image_nodes=group_image_nodes)
 
     def _update_graph_view(self, dotcode):
         if dotcode == self._current_dotcode:
@@ -337,6 +343,7 @@ class RosGraph(Plugin):
         self._widget.unreachable_check_box.setEnabled(False)
         self._widget.group_tf_check_box.setEnabled(False)
         self._widget.hide_tf_nodes_check_box.setEnabled(False)
+        self._widget.group_image_check_box.setEnabled(False)
 
         self._update_graph_view(dotcode)
 

--- a/src/rqt_graph/ros_graph.py
+++ b/src/rqt_graph/ros_graph.py
@@ -153,6 +153,8 @@ class RosGraph(Plugin):
         self._widget.leaf_topics_check_box.clicked.connect(self._refresh_rosgraph)
         self._widget.quiet_check_box.clicked.connect(self._refresh_rosgraph)
         self._widget.unreachable_check_box.clicked.connect(self._refresh_rosgraph)
+        self._widget.group_tf_check_box.clicked.connect(self._refresh_rosgraph)
+        self._widget.hide_tf_nodes_check_box.clicked.connect(self._refresh_rosgraph)
 
         self._widget.refresh_graph_push_button.setIcon(QIcon.fromTheme('view-refresh'))
         self._widget.refresh_graph_push_button.pressed.connect(self._update_rosgraph)
@@ -189,6 +191,8 @@ class RosGraph(Plugin):
         instance_settings.set_value('unreachable_check_box_state', self._widget.unreachable_check_box.isChecked())
         instance_settings.set_value('auto_fit_graph_check_box_state', self._widget.auto_fit_graph_check_box.isChecked())
         instance_settings.set_value('highlight_connections_check_box_state', self._widget.highlight_connections_check_box.isChecked())
+        instance_settings.set_value('group_tf_check_box_state', self._widget.group_tf_check_box.isChecked())
+        instance_settings.set_value('hide_tf_nodes_check_box_state', self._widget.hide_tf_nodes_check_box.isChecked())
 
     def restore_settings(self, plugin_settings, instance_settings):
         self._widget.graph_type_combo_box.setCurrentIndex(int(instance_settings.value('graph_type_combo_box_index', 0)))
@@ -202,6 +206,8 @@ class RosGraph(Plugin):
         self._widget.unreachable_check_box.setChecked(instance_settings.value('unreachable_check_box_state', True) in [True, 'true'])
         self._widget.auto_fit_graph_check_box.setChecked(instance_settings.value('auto_fit_graph_check_box_state', True) in [True, 'true'])
         self._widget.highlight_connections_check_box.setChecked(instance_settings.value('highlight_connections_check_box_state', True) in [True, 'true'])
+        self._widget.hide_tf_nodes_check_box.setChecked(instance_settings.value('hide_tf_nodes_check_box_state', False) in [True, 'true'])
+        self._widget.group_tf_check_box.setChecked(instance_settings.value('group_tf_check_box_state', True) in [True, 'true'])
         self.initialized = True
         self._refresh_rosgraph()
 
@@ -216,6 +222,8 @@ class RosGraph(Plugin):
         self._widget.leaf_topics_check_box.setEnabled(True)
         self._widget.quiet_check_box.setEnabled(True)
         self._widget.unreachable_check_box.setEnabled(True)
+        self._widget.group_tf_check_box.setEnabled(True)
+        self._widget.hide_tf_nodes_check_box.setEnabled(True)
 
         self._graph = rosgraph.impl.graph.Graph()
         self._graph.set_master_stale(5.0)
@@ -241,6 +249,8 @@ class RosGraph(Plugin):
         hide_single_connection_topics = self._widget.leaf_topics_check_box.isChecked()
         quiet = self._widget.quiet_check_box.isChecked()
         unreachable = self._widget.unreachable_check_box.isChecked()
+        group_tf_nodes = self._widget.group_tf_check_box.isChecked()
+        hide_tf_nodes = self._widget.hide_tf_nodes_check_box.isChecked()
 
         return self.dotcode_generator.generate_dotcode(
             rosgraphinst=self._graph,
@@ -254,7 +264,9 @@ class RosGraph(Plugin):
             dotcode_factory=self.dotcode_factory,
             orientation=orientation,
             quiet=quiet,
-            unreachable=unreachable)
+            unreachable=unreachable,
+            group_tf_nodes=group_tf_nodes,
+            hide_tf_nodes=hide_tf_nodes)
 
     def _update_graph_view(self, dotcode):
         if dotcode == self._current_dotcode:
@@ -323,6 +335,8 @@ class RosGraph(Plugin):
         self._widget.leaf_topics_check_box.setEnabled(False)
         self._widget.quiet_check_box.setEnabled(False)
         self._widget.unreachable_check_box.setEnabled(False)
+        self._widget.group_tf_check_box.setEnabled(False)
+        self._widget.hide_tf_nodes_check_box.setEnabled(False)
 
         self._update_graph_view(dotcode)
 

--- a/src/rqt_graph/ros_graph.py
+++ b/src/rqt_graph/ros_graph.py
@@ -195,6 +195,7 @@ class RosGraph(Plugin):
         instance_settings.set_value('group_tf_check_box_state', self._widget.group_tf_check_box.isChecked())
         instance_settings.set_value('hide_tf_nodes_check_box_state', self._widget.hide_tf_nodes_check_box.isChecked())
         instance_settings.set_value('group_image_check_box_state', self._widget.group_image_check_box.isChecked())
+        instance_settings.set_value('hide_dynamic_reconfigure_check_box_state', self._widget.hide_dynamic_reconfigure_check_box.isChecked())
 
     def restore_settings(self, plugin_settings, instance_settings):
         self._widget.graph_type_combo_box.setCurrentIndex(int(instance_settings.value('graph_type_combo_box_index', 0)))
@@ -211,6 +212,7 @@ class RosGraph(Plugin):
         self._widget.hide_tf_nodes_check_box.setChecked(instance_settings.value('hide_tf_nodes_check_box_state', False) in [True, 'true'])
         self._widget.group_tf_check_box.setChecked(instance_settings.value('group_tf_check_box_state', True) in [True, 'true'])
         self._widget.group_image_check_box.setChecked(instance_settings.value('group_image_check_box_state', True) in [True, 'true'])
+        self._widget.hide_dynamic_reconfigure_check_box.setChecked(instance_settings.value('hide_dynamic_reconfigure_check_box_state', True) in [True, 'true'])
         self.initialized = True
         self._refresh_rosgraph()
 
@@ -228,6 +230,7 @@ class RosGraph(Plugin):
         self._widget.group_tf_check_box.setEnabled(True)
         self._widget.hide_tf_nodes_check_box.setEnabled(True)
         self._widget.group_image_check_box.setEnabled(True)
+        self._widget.hide_dynamic_reconfigure_check_box.setEnabled(True)
 
         self._graph = rosgraph.impl.graph.Graph()
         self._graph.set_master_stale(5.0)
@@ -256,6 +259,7 @@ class RosGraph(Plugin):
         group_tf_nodes = self._widget.group_tf_check_box.isChecked()
         hide_tf_nodes = self._widget.hide_tf_nodes_check_box.isChecked()
         group_image_nodes = self._widget.group_image_check_box.isChecked()
+        hide_dynamic_reconfigure = self._widget.hide_dynamic_reconfigure_check_box.isChecked()
 
         return self.dotcode_generator.generate_dotcode(
             rosgraphinst=self._graph,
@@ -272,7 +276,8 @@ class RosGraph(Plugin):
             unreachable=unreachable,
             group_tf_nodes=group_tf_nodes,
             hide_tf_nodes=hide_tf_nodes,
-            group_image_nodes=group_image_nodes)
+            group_image_nodes=group_image_nodes,
+            hide_dynamic_reconfigure=hide_dynamic_reconfigure)
 
     def _update_graph_view(self, dotcode):
         if dotcode == self._current_dotcode:
@@ -344,6 +349,7 @@ class RosGraph(Plugin):
         self._widget.group_tf_check_box.setEnabled(False)
         self._widget.hide_tf_nodes_check_box.setEnabled(False)
         self._widget.group_image_check_box.setEnabled(False)
+        self._widget.hide_dynamic_reconfigure_check_box.setEnabled(False)
 
         self._update_graph_view(dotcode)
 

--- a/src/rqt_graph/ros_graph.py
+++ b/src/rqt_graph/ros_graph.py
@@ -147,7 +147,7 @@ class RosGraph(Plugin):
         self._widget.topic_filter_line_edit.editingFinished.connect(self._refresh_rosgraph)
         self._widget.topic_filter_line_edit.setCompleter(topic_completer)
 
-        self._widget.namespace_cluster_check_box.clicked.connect(self._refresh_rosgraph)
+        self._widget.namespace_cluster_spin_box.valueChanged.connect(self._refresh_rosgraph)
         self._widget.actionlib_check_box.clicked.connect(self._refresh_rosgraph)
         self._widget.dead_sinks_check_box.clicked.connect(self._refresh_rosgraph)
         self._widget.leaf_topics_check_box.clicked.connect(self._refresh_rosgraph)
@@ -181,7 +181,7 @@ class RosGraph(Plugin):
         instance_settings.set_value('graph_type_combo_box_index', self._widget.graph_type_combo_box.currentIndex())
         instance_settings.set_value('filter_line_edit_text', self._widget.filter_line_edit.text())
         instance_settings.set_value('topic_filter_line_edit_text', self._widget.topic_filter_line_edit.text())
-        instance_settings.set_value('namespace_cluster_check_box_state', self._widget.namespace_cluster_check_box.isChecked())
+        instance_settings.set_value('namespace_cluster_spin_box_value', self._widget.namespace_cluster_spin_box.value())
         instance_settings.set_value('actionlib_check_box_state', self._widget.actionlib_check_box.isChecked())
         instance_settings.set_value('dead_sinks_check_box_state', self._widget.dead_sinks_check_box.isChecked())
         instance_settings.set_value('leaf_topics_check_box_state', self._widget.leaf_topics_check_box.isChecked())
@@ -194,7 +194,7 @@ class RosGraph(Plugin):
         self._widget.graph_type_combo_box.setCurrentIndex(int(instance_settings.value('graph_type_combo_box_index', 0)))
         self._widget.filter_line_edit.setText(instance_settings.value('filter_line_edit_text', '/'))
         self._widget.topic_filter_line_edit.setText(instance_settings.value('topic_filter_line_edit_text', '/'))
-        self._widget.namespace_cluster_check_box.setChecked(instance_settings.value('namespace_cluster_check_box_state', True) in [True, 'true'])
+        self._widget.namespace_cluster_spin_box.setValue(int(instance_settings.value('namespace_cluster_spin_box_value', 2)))
         self._widget.actionlib_check_box.setChecked(instance_settings.value('actionlib_check_box_state', True) in [True, 'true'])
         self._widget.dead_sinks_check_box.setChecked(instance_settings.value('dead_sinks_check_box_state', True) in [True, 'true'])
         self._widget.leaf_topics_check_box.setChecked(instance_settings.value('leaf_topics_check_box_state', True) in [True, 'true'])
@@ -210,7 +210,7 @@ class RosGraph(Plugin):
         self._widget.graph_type_combo_box.setEnabled(True)
         self._widget.filter_line_edit.setEnabled(True)
         self._widget.topic_filter_line_edit.setEnabled(True)
-        self._widget.namespace_cluster_check_box.setEnabled(True)
+        self._widget.namespace_cluster_spin_box.setEnabled(True)
         self._widget.actionlib_check_box.setEnabled(True)
         self._widget.dead_sinks_check_box.setEnabled(True)
         self._widget.leaf_topics_check_box.setEnabled(True)
@@ -235,10 +235,7 @@ class RosGraph(Plugin):
         topic_filter = self._widget.topic_filter_line_edit.text()
         graph_mode = self._widget.graph_type_combo_box.itemData(self._widget.graph_type_combo_box.currentIndex())
         orientation = 'LR'
-        if self._widget.namespace_cluster_check_box.isChecked():
-            namespace_cluster = 1
-        else:
-            namespace_cluster = 0
+        namespace_cluster = self._widget.namespace_cluster_spin_box.value()
         accumulate_actions = self._widget.actionlib_check_box.isChecked()
         hide_dead_end_topics = self._widget.dead_sinks_check_box.isChecked()
         hide_single_connection_topics = self._widget.leaf_topics_check_box.isChecked()
@@ -296,13 +293,8 @@ class RosGraph(Plugin):
         # layout graph and create qt items
         (nodes, edges) = self.dot_to_qt.dotcode_to_qt_items(self._current_dotcode,
                                                             highlight_level=highlight_level,
-                                                            same_label_siblings=True)
-
-        for node_item in nodes.values():
-            self._scene.addItem(node_item)
-        for edge_items in edges.values():
-            for edge_item in edge_items:
-                edge_item.add_to_scene(self._scene)
+                                                            same_label_siblings=True,
+                                                            scene=self._scene)
 
         self._scene.setSceneRect(self._scene.itemsBoundingRect())
         if self._widget.auto_fit_graph_check_box.isChecked():


### PR DESCRIPTION
rqt_graph has had a long-standing problem; in real use cases, graphs quickly become unwieldy and unreadable, with dynamic reconfigure's parameter topics everywhere, and don't even start with images. 

This pull request aims to solve these problems with several changes, including:

* Added nested subnamespaces. The "Group Namespaces" checkbox has been replaced with a spin box, allowing users to enter the number of levels of grouping they desire.
* Grouped topics (such as action topics) now display as 3D boxes.
* Added a checkbox allowing the grouping of topics added by tf2 (from ros/geometry2) (i.e. /tf and /tf_static), in a manner similar to action topics.
* Added a checkbox allowing the hiding of topics added by tf2 (from ros/geometry2) (i.e. /tf and /tf_static).
* Added a checkbox allowing the grouping of topics added by image_transport (from ros-perception/image_common) (i.e. /, /compressed, /theora, and /compressedDepth), in a manner similar to action topics.
* Added a checkbox allowing the hiding of topics added by dynamic_reconfigure (from ros/dynamic_reconfigure) (i.e. /parameter_descriptions and /parameter_updates).

These changes, originally implemented in ros-visualization/rqt_graph#9, have been split into six separate commits, with formatting changes removed, for ease of review.

These changes are dependent on pull request ros-visualization/qt_gui_core#87.

Note that the Hide section of the toolbar has been shifted down to a new line, and margins have been changed as the creation of a new line caused spacing problems.

Three files are attached to this pull request; the launch file I used for testing, a before picture, and an after picture, displaying what rqt_graph looks like before and after the changes.
[Attachments(1).zip](https://github.com/ros-visualization/rqt_graph/files/1195298/Attachments.1.zip)