### PR TITLE
Fix error when using rqt_graph with Python 3 with compressed image topics present

### DIFF
--- a/src/rqt_graph/dotcode.py
+++ b/src/rqt_graph/dotcode.py
@@ -430,15 +430,15 @@ class RosGraphDotcodeGenerator:
             if str(n).endswith('/feedback'):
                 prefix = str(n)[:-len('/feedback')].strip()
                 action_topic_nodes = []
-                action_topic_edges_out = set()
-                action_topic_edges_in = set()
+                action_topic_edges_out = list()
+                action_topic_edges_in = list()
                 for suffix in ['/status', '/result', '/goal', '/cancel', '/feedback']:
                     for n2 in nodes:
                         if str(n2).strip() == prefix + suffix:
                             action_topic_nodes.append(n2)
                             if n2 in node_connections:
-                                action_topic_edges_out.update(node_connections[n2].outgoing)
-                                action_topic_edges_in.update(node_connections[n2].incoming)
+                                action_topic_edges_out.extend(node_connections[n2].outgoing)
+                                action_topic_edges_in.extend(node_connections[n2].incoming)
                 if len(action_topic_nodes) == 5:
                     # found action
                     removal_nodes.extend(action_topic_nodes)
@@ -503,15 +503,15 @@ class RosGraphDotcodeGenerator:
         edges where the edges to tf topics have been removed, and
         a map with all the connections to the resulting tf group node'''
         removal_nodes = []
-        tf_topic_edges_in = set()
-        tf_topic_edges_out = set()
+        tf_topic_edges_in = list()
+        tf_topic_edges_out = list()
         # do not manipulate incoming structures
         nodes = copy.copy(nodes_in)
         edges = copy.copy(edges_in)
         for n in nodes:
             if str(n).strip() in ['/tf', '/tf_static']:
-                tf_topic_edges_in.update([x for x in node_connections[n].incoming if x in edges and x.end in nodes])
-                tf_topic_edges_out.update([x for x in node_connections[n].outgoing if x in edges and x.start in nodes])
+                tf_topic_edges_in.extend([x for x in node_connections[n].incoming if x in edges and x.end in nodes])
+                tf_topic_edges_out.extend([x for x in node_connections[n].outgoing if x in edges and x.start in nodes])
                 removal_nodes.append(n)
 
                 for e in tf_topic_edges_out:
@@ -542,15 +542,15 @@ class RosGraphDotcodeGenerator:
             if str(n).endswith('/compressed'):
                 prefix = str(n)[:-len('/compressed')].strip()
                 image_topic_nodes = []
-                image_topic_edges_out = set()
-                image_topic_edges_in = set()
+                image_topic_edges_out = list()
+                image_topic_edges_in = list()
                 for suffix in ['/compressed', '/compressedDepth', '/theora', '']:
                     for n2 in nodes:
                         if str(n2).strip() == prefix + suffix:
                             image_topic_nodes.append(n2)
                             if n2 in node_connections:
-                                image_topic_edges_out.update(node_connections[n2].outgoing)
-                                image_topic_edges_in.update(node_connections[n2].incoming)
+                                image_topic_edges_out.extend(node_connections[n2].outgoing)
+                                image_topic_edges_in.extend(node_connections[n2].incoming)
                 if len(image_topic_nodes) >= 3:
                     # found action
                     removal_nodes.extend(image_topic_nodes)


### PR DESCRIPTION
Better fix for the issue reported in https://github.com/ros/ros_comm/pull/1457.

When using rqt_graph with Python 3 with compressed image topics present, it leads to the error:
```python
PluginHandlerDirect._restore_settings() plugin "rqt_graph/RosGraph#0" raised an exception:
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python3.6/site-packages/qt_gui/plugin_handler_direct.py", line 116, in _restore_settings
    self._plugin.restore_settings(plugin_settings_plugin, instance_settings_plugin)
  File "/opt/ros/melodic/lib/python3.6/site-packages/rqt_graph/ros_graph.py", line 217, in restore_settings
    self._refresh_rosgraph()
  File "/opt/ros/melodic/lib/python3.6/site-packages/rqt_graph/ros_graph.py", line 246, in _refresh_rosgraph
    self._update_graph_view(self._generate_dotcode())
  File "/opt/ros/melodic/lib/python3.6/site-packages/rqt_graph/ros_graph.py", line 280, in _generate_dotcode
    hide_dynamic_reconfigure=hide_dynamic_reconfigure)
  File "/opt/ros/melodic/lib/python3.6/site-packages/rqt_graph/dotcode.py", line 876, in generate_dotcode
    hide_dynamic_reconfigure=hide_dynamic_reconfigure)
  File "/opt/ros/melodic/lib/python3.6/site-packages/rqt_graph/dotcode.py", line 698, in generate_dotgraph
    nt_nodes, edges, image_nodes = self._accumulate_image_topics(nt_nodes, edges, node_connections)
  File "/opt/ros/melodic/lib/python3.6/site-packages/rqt_graph/dotcode.py", line 553, in _accumulate_image_topics
    image_topic_edges_in.update(node_connections[n2].incoming)
TypeError: unhashable type: 'Edge'
```
