### PR TITLE
Use unicode version of str()

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
 
   <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>python-rospkg</run_depend>
+  <run_depend>python-future</run_depend>
   <run_depend>qt_dotgraph</run_depend>
   <run_depend>rosgraph</run_depend>
   <run_depend>rosgraph_msgs</run_depend>

--- a/src/rqt_graph/dotcode.py
+++ b/src/rqt_graph/dotcode.py
@@ -32,6 +32,8 @@
 
 # this is a modified version of rx/rxgraph/src/rxgraph/dotcode.py
 
+from builtins import str
+
 import re
 import copy
 

--- a/src/rqt_graph/ros_graph.py
+++ b/src/rqt_graph/ros_graph.py
@@ -29,6 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import division
+from builtins import str
 import os
 import rospkg
 


### PR DESCRIPTION
This commit fixes the following bug: If the user entered a non-ASCII character into one of the filter text boxes (for example, by hitting the 'ü' key on a German keyboard by accident), the application crashed before with the following error:

    Traceback (most recent call last):
      File "~/catkin_ws/src/rqt_graph/src/rqt_graph/ros_graph.py", line 69, in splitPath
        path = str(path.split(',')[-1]).lstrip(' ')
    UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 16: ordinal not in range(128)

The python3 str() function does the same as the python2 unicode() function. By importing str() from builtins, the code is compatible with both python2 and python3.