### PR TITLE
Remove edge simplification from node-only graph.

### DIFF
--- a/src/rqt_graph/dotcode.py
+++ b/src/rqt_graph/dotcode.py
@@ -209,7 +209,7 @@ class RosGraphDotcodeGenerator:
         else:
             return [None, None, None]
 
-    def _add_edge(self, edge, dotcode_factory, dotgraph, is_topic=False):
+    def _add_edge(self, edge, dotcode_factory, dotgraph, is_topic=False, simplify=True):
         if is_topic:
             sub = edge.end
             topic = edge.label
@@ -224,14 +224,16 @@ class RosGraphDotcodeGenerator:
                     label=temp_label,
                     url='topic:%s' % edge.label,
                     penwidth=penwidth,
-                    color=color)
+                    color=color,
+                    simplify=simplify)
             else:
                 dotcode_factory.add_edge_to_graph(
                     dotgraph,
                     _conv(edge.start),
                     _conv(edge.end),
                     label=edge.label,
-                    url='topic:%s' % edge.label)
+                    url='topic:%s' % edge.label,
+                    simplify=simplify)
         else:
             sub = edge.end.strip()
             topic = edge.start.strip()
@@ -822,7 +824,7 @@ class RosGraphDotcodeGenerator:
 
         for e in edges:
             self._add_edge(
-                e, dotcode_factory, dotgraph=dotgraph, is_topic=(graph_mode == NODE_NODE_GRAPH))
+                e, dotcode_factory, dotgraph=dotgraph, is_topic=(graph_mode == NODE_NODE_GRAPH), simplify=simplify)
 
         for (action_prefix, node_connections) in action_nodes.items():
             for out_edge in node_connections.get('outgoing', []):

--- a/src/rqt_graph/ros_graph.py
+++ b/src/rqt_graph/ros_graph.py
@@ -304,6 +304,7 @@ class RosGraph(Plugin):
         hide_tf_nodes = self._widget.hide_tf_nodes_check_box.isChecked()
         group_image_nodes = self._widget.group_image_check_box.isChecked()
         hide_dynamic_reconfigure = self._widget.hide_dynamic_reconfigure_check_box.isChecked()
+        simplify = (graph_mode != NODE_NODE_GRAPH)
 
         return self.dotcode_generator.generate_dotcode(
             rosgraphinst=self._graph,
@@ -321,7 +322,8 @@ class RosGraph(Plugin):
             group_tf_nodes=group_tf_nodes,
             hide_tf_nodes=hide_tf_nodes,
             group_image_nodes=group_image_nodes,
-            hide_dynamic_reconfigure=hide_dynamic_reconfigure)
+            hide_dynamic_reconfigure=hide_dynamic_reconfigure,
+            simplify=simplify)
 
     def _update_graph_view(self, dotcode):
         if dotcode == self._current_dotcode:


### PR DESCRIPTION
Previously, when there were multiple topics between two nodes, only one of the topics was being displayed.  This was caused by graph simplification flag not being passed into the edge-adding code.
Graph simplification was also defaulting to True, when in fact it should be false for the node-to-node graph.

Addresses issue:
https://github.com/ros-visualization/rqt_graph/issues/20 - In "Nodes only" mode, multiple topics not shown
