### PR TITLE
Fix node not found during refresh when namespace is not empty

### DIFF
--- a/src/rqt_graph/rosgraph2_impl.py
+++ b/src/rqt_graph/rosgraph2_impl.py
@@ -414,10 +414,9 @@ class Graph(object):
         return updated
 
     def _node_uri_refresh(self, node):
-        current_nodes = []
-        for name, namespace in self._node.get_node_names_and_namespaces():
-            node_name = namespace + name if namespace.endswith('/') else namespace + '/' + name
-            current_nodes.append(node_name)
+        current_nodes = {
+            namespace + (' ' if namespace.endswith('/') else '/') + name
+            for name, namespace in self._node.get_node_names_and_namespaces()}
         if node not in current_nodes:
             qWarning('Node "{}" does not exist'.format(node))
             return None

--- a/src/rqt_graph/rosgraph2_impl.py
+++ b/src/rqt_graph/rosgraph2_impl.py
@@ -414,8 +414,10 @@ class Graph(object):
         return updated
 
     def _node_uri_refresh(self, node):
-        current_nodes = \
-            {namespace + name for name, namespace in self._node.get_node_names_and_namespaces()}
+        current_nodes = []
+        for name, namespace in self._node.get_node_names_and_namespaces():
+            node_name = namespace + name if namespace.endswith('/') else namespace + '/' + name
+            current_nodes.append(node_name)
         if node not in current_nodes:
             qWarning('Node "{}" does not exist'.format(node))
             return None


### PR DESCRIPTION
Hello,

I am playing with ROS2 Dashing.

I noticed that  nodes with namespaces were not found by rqt_graph during refresh.
Warning Message example:  _Node "/can2ros/control_can" does not exist_

I found an issue in src/rqt_graph/rosgraph2_impl.py:_node_uri_refresh

When there is a namespace not empty, the '/' is missing

This PR fix this issue.


Best Regards,
Xavier.



Signed-off-by: Xavier BROQUERE <xav.broquere@gmail.com>