### PR TITLE
Add setup.cfg with script install directories

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script-dir=$base/lib/rqt_graph
+[install]
+install-scripts=$base/lib/rqt_graph


### PR DESCRIPTION
Fixed package to run with `ros2 run rqt_graph rqt_graph`. Related to this issue https://github.com/ros-visualization/rqt_console/issues/20