### PR TITLE
[Noetic] Use catkin_install_python()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,6 @@ install(DIRECTORY resource
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-install(PROGRAMS scripts/rqt_graph
+catkin_install_python(PROGRAMS scripts/rqt_graph
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
     packages=['rqt_graph'],
-    package_dir={'': 'src'},
-    scripts=['scripts/rqt_graph']
+    package_dir={'': 'src'}
 )
 
 setup(**d)


### PR DESCRIPTION
This uses `catkin_install_python()` instead of a mix of install and the setup.py scripts argument to make sure the shebang gets rewritten.

It fixes a bug in the current debian package I encountered here: http://wiki.ros.org/ROS/Tutorials/UnderstandingTopics#Using_rqt_graph

```console
$ rosrun rqt_graph rqt_graph 
/usr/bin/env: ‘python’: No such file or directory
```

@dirk-thomas got time to make another Noetic release with this fix? If not, with your permission I can make one.