### PR TITLE
[crystal] Revert "Add setup.cfg with script install directories (#42)"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[develop]
-script-dir=$base/lib/rqt_graph
-[install]
-install-scripts=$base/lib/rqt_graph


### PR DESCRIPTION
This reverts commit 4139a3957acc0b3e2e8258cca9ddb46f62258190.

This fixes a regression, where we can no longer invoke the `rqt_graph` without `ros2 run`.