### PR TITLE
show byte/message in statistics mode

### DIFF
--- a/src/rqt_graph/dotcode.py
+++ b/src/rqt_graph/dotcode.py
@@ -204,7 +204,16 @@ class RosGraphDotcodeGenerator:
             age_string = ""
             if age > 0.0:
                 age_string = " // " + unicode(round(age, 2) * 1000) + " ms"
-            label = freq + " Hz" + age_string
+            if self.edges[sub][topic][pub].traffic > 0 :
+                traffic = self.edges[sub][topic][pub].traffic / self.edges[sub][topic][pub].delivered_msgs
+            else:
+                traffic = 0
+            traffic_string = "{}".format(traffic)
+            if traffic > 1000:
+                traffic_string = "{}K".format(traffic/1000)
+            if traffic > 1000000:
+                traffic_string = "{}M".format(traffic/1000000)
+            label = freq + " Hz" + age_string + " // " + traffic_string
             return [label, penwidth, color]
         else:
             return [None, None, None]


### PR DESCRIPTION
examples:

need to set `rosparam set enable_statistics true` to show statistics on `rqt_graph`.

raw connection:

![rosgraph-raw](https://user-images.githubusercontent.com/493276/101662178-879d5680-3a8c-11eb-86cf-6b09e4450890.png)

compressed connection:

![rosgraph-compressed](https://user-images.githubusercontent.com/493276/101662193-8c620a80-3a8c-11eb-9987-e183ba77d740.png)
