### PR TITLE
Add node name, topic name, and endpoint kind to the qos edge tooltip

### DIFF
--- a/src/rqt_graph/dotcode.py
+++ b/src/rqt_graph/dotcode.py
@@ -238,6 +238,8 @@ class RosGraphDotcodeGenerator:
     def _qos_to_string(self, start, end, qos):
         if qos is None:
             return None
+        # topic names are prefixed with an space, unlike node names
+        # see rosgraph2_impl.topic_node()
         if start[0] == ' ':
             topic_name = start[1:]
             node_name = end

--- a/src/rqt_graph/dotcode.py
+++ b/src/rqt_graph/dotcode.py
@@ -226,19 +226,27 @@ class RosGraphDotcodeGenerator:
                     label=temp_label,
                     penwidth=penwidth,
                     color=color,
-                    edgetooltip=self._qos_to_string(edge.qos))
+                    edgetooltip=self._qos_to_string(edge.start, edge.end, edge.qos))
             else:
                 dotcode_factory.add_edge_to_graph(
                     dotgraph,
                     _conv(edge.start),
                     _conv(edge.end),
                     label=edge.label,
-                    edgetooltip=self._qos_to_string(edge.qos))
+                    edgetooltip=self._qos_to_string(edge.start, edge.end, edge.qos))
 
-    def _qos_to_string(self, qos):
+    def _qos_to_string(self, start, end, qos):
         if qos is None:
             return None
-        s = 'QoS settings'
+        if start[0] == ' ':
+            topic_name = start[1:]
+            node_name = end
+            endpoint = 'Subscription'
+        else:
+            topic_name = end[1:]
+            node_name = start
+            endpoint = 'Publisher'
+        s = f'{endpoint}\nnode_name: {node_name}\ntopic_name: {topic_name}\nQoS settings'
         for slot_name in qos.__slots__:
             property_name = slot_name[1:]
             # ignore values currently not introspectable
@@ -251,7 +259,7 @@ class RosGraphDotcodeGenerator:
                 value = value.short_key
             elif hasattr(value, 'nanoseconds'):
                 value = str(value.nanoseconds) + ' ns'
-            s += '\n- %s: %s' % (property_name, value)
+            s += f'\n- {property_name}: {value}'
         return s
 
     def _add_node(self, node, rosgraphinst, dotcode_factory, dotgraph, unreachable):


### PR DESCRIPTION
Mitigates https://github.com/ros-visualization/rqt_graph/issues/59.

When there are many edges the tooltip showed might be wrong (likely a problem in some of the dependencies).
This adds more information to the tooltip so the user can realize what's happening.

Not great, but better ...