### PR TITLE
Make topics that have qos incompatibilities red in the graph

### DIFF
--- a/src/rqt_graph/dotcode.py
+++ b/src/rqt_graph/dotcode.py
@@ -304,15 +304,25 @@ class RosGraphDotcodeGenerator:
     def _add_topic_node(self, node, rosgraphinst, dotcode_factory, dotgraph, quiet):
         label = rosgraph2_impl.node_topic(node)
         color = None
+        tooltip = None
         if label in rosgraphinst.topic_with_qos_incompatibility:
             color = 'red'
+            tooltip_split = ['Found qos incompatibilities:', '']
+            tooltip_split.extend([
+                f'- Publisher of node `{pub_node}` '
+                f'incompatible with subscriptions of nodes `{", ".join(sub_node_list)}`'
+                for pub_node, sub_node_list in
+                rosgraphinst.topic_with_qos_incompatibility[label].items()])
+            tooltip_split.extend(['', f'Use `ros2 topic info -v {label}` to check the qos profiles'])
+            tooltip = '<br/>'.join(tooltip_split)
         dotcode_factory.add_node_to_graph(
             dotgraph,
             nodename=_conv(node),
             nodelabel=label,
             shape='box',
             url="topic:%s" % label,
-            color=color)
+            color=color,
+            tooltip=tooltip)
 
     def _add_topic_node_group(self, node, dotcode_factory, dotgraph, quiet):
         label = rosgraph2_impl.node_topic(node)

--- a/src/rqt_graph/dotcode.py
+++ b/src/rqt_graph/dotcode.py
@@ -301,14 +301,18 @@ class RosGraphDotcodeGenerator:
                 shape='ellipse',
                 url=node)
 
-    def _add_topic_node(self, node, dotcode_factory, dotgraph, quiet):
+    def _add_topic_node(self, node, rosgraphinst, dotcode_factory, dotgraph, quiet):
         label = rosgraph2_impl.node_topic(node)
+        color = None
+        if label in rosgraphinst.topic_with_qos_incompatibility:
+            color = 'red'
         dotcode_factory.add_node_to_graph(
             dotgraph,
             nodename=_conv(node),
             nodelabel=label,
             shape='box',
-            url="topic:%s" % label)
+            url="topic:%s" % label,
+            color=color)
 
     def _add_topic_node_group(self, node, dotcode_factory, dotgraph, quiet):
         label = rosgraph2_impl.node_topic(node)
@@ -788,11 +792,15 @@ class RosGraphDotcodeGenerator:
                 else:
                     namespace = '/'.join(n.strip().split('/')[:cluster_namespaces_level + 1])
                 self._add_topic_node(
-                    n, dotcode_factory=dotcode_factory, dotgraph=namespace_clusters[namespace],
+                    n,
+                    rosgraphinst=rosgraphinst,
+                    dotcode_factory=dotcode_factory, dotgraph=namespace_clusters[namespace],
                     quiet=quiet)
             else:
                 self._add_topic_node(
-                    n, dotcode_factory=dotcode_factory, dotgraph=dotgraph, quiet=quiet)
+                    n,
+                    rosgraphinst=rosgraphinst,
+                    dotcode_factory=dotcode_factory, dotgraph=dotgraph, quiet=quiet)
 
         for n in [act_prefix + ACTION_TOPICS_SUFFIX for act_prefix, _ in action_nodes.items()] + \
                 [img_prefix + IMAGE_TOPICS_SUFFIX for img_prefix, _ in image_nodes.items()]:


### PR DESCRIPTION
Depends on https://github.com/ros2/rclpy/pull/708.

Slightly related to https://github.com/ros-visualization/rqt_graph/issues/59.
This automatically detects qos incompatibilities and shows them in the graph by coloring the topic node red.

![image](https://user-images.githubusercontent.com/26796393/112530961-c8905100-8d85-11eb-9c84-aa836f0b3996.png)

More information could be provided to the user, but I'm not sure how to make it look nice: not sure if node tooltips will be reliable, adding more text to the node label might not look nice, ...

@jacobperron ideas?