### PR TITLE
[galactic] Fix quiet filtering for node_topic graphs

### DIFF
--- a/src/rqt_graph/dotcode.py
+++ b/src/rqt_graph/dotcode.py
@@ -761,10 +761,8 @@ class RosGraphDotcodeGenerator:
 
         if quiet:
             nn_nodes = list(filter(self._quiet_filter, nn_nodes))
-            if graph_mode == NODE_NODE_GRAPH:
-                edges = list(filter(self.quiet_filter_topic_edge, edges))
-            else:
-                nt_nodes = list(filter(self._quiet_filter, nt_nodes))
+            nt_nodes = list(filter(self._quiet_filter, nt_nodes))
+            edges = list(filter(self.quiet_filter_topic_edge, edges))
 
         # create the graph
         # result = "digraph G {\n


### PR DESCRIPTION
## New version of PR #69 based on galactic-devel

Here's a standard graph with Debug/Quiet=False

![Screenshot from 2021-09-28 10-44-57](https://user-images.githubusercontent.com/1016143/135110765-1a0e7c8b-f06a-47ee-96aa-46608ebddbcf.png)

However, when we turn on Debug/Quiet, we are not correctly filtering the edges.
![Screenshot from 2021-09-28 10-44-53](https://user-images.githubusercontent.com/1016143/135110867-cc207dd4-619e-4077-9dc3-069f7cd90d7e.png)
 
This is an effect of the nodes being properly filtered, but the edges not being filtered, so new nodes with the dot node names (`t__rosout`) are created. 

The new logic always filters the edges (instead of just when `graph_mode == NODE_NODE_GRAPH`. We also always filter the `nt_nodes`, which is just empty if `graph_mode == NODE_NODE_GRAPH`. 

@hidmic I think you wrote this bit of logic originally in #35 
