### PR TITLE
encode in utf-8 before saving graph dot file

### DIFF
--- a/src/rqt_graph/ros_graph.py
+++ b/src/rqt_graph/ros_graph.py
@@ -411,7 +411,7 @@ class RosGraph(Plugin):
         if not handle.open(QIODevice.WriteOnly | QIODevice.Text):
             return
 
-        handle.write(self._current_dotcode)
+        handle.write(self._current_dotcode.encode('utf-8'))
         handle.close()
 
     def _save_svg(self):


### PR DESCRIPTION
It fixes issue https://github.com/ros-visualization/rqt_graph/issues/85