### PR TITLE
add warning for type incompatibilities

### DIFF
--- a/src/rqt_graph/dotcode.py
+++ b/src/rqt_graph/dotcode.py
@@ -302,6 +302,17 @@ class RosGraphDotcodeGenerator:
             tooltip_split.extend(
                 ['', f'Use `ros2 topic info -v {label}` to check the qos profiles'])
             tooltip = '<br/>'.join(tooltip_split)
+        if label in rosgraphinst.topic_with_type_incompatibility:
+            color = 'red'
+            tooltip_split = ['Found type incompatibilities:', '']
+            tooltip_split.extend([
+                f'- Publisher of node `{pub_node}` '
+                f'incompatible with subscriptions of nodes `{", ".join(sub_node_list)}`'
+                for pub_node, sub_node_list in
+                rosgraphinst.topic_with_type_incompatibility[label].items()])
+            tooltip_split.extend(
+                ['', f'Use `ros2 topic info -v {label}` to check types'])
+            tooltip = '<br/>'.join(tooltip_split)
         dotcode_factory.add_node_to_graph(
             dotgraph,
             nodename=_conv(node),

--- a/src/rqt_graph/rosgraph2_impl.py
+++ b/src/rqt_graph/rosgraph2_impl.py
@@ -274,6 +274,9 @@ class Graph(object):
         # {topic_name: {publisher_node_name: [subscription_node_name, ...], ...}, ...}
         self.topic_with_qos_incompatibility = defaultdict(lambda: defaultdict(list))
 
+        # same type as topic_with_qos_incompatibility
+        self.topic_with_type_incompatibility : dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
+
     def set_node_stale(self, stale_secs):
         """
         Set the stale attribute of a node.
@@ -298,17 +301,23 @@ class Graph(object):
         publisher_topic_names = set()
         subscriber_topic_names = set()
 
+        # {topic_name: {node_name: [type1, ...]}}
+        publisher_topic_types = defaultdict(lambda: defaultdict(list))
+        subscriber_topic_types = defaultdict(lambda: defaultdict(list))
+
         for name, namespace in self._node.get_node_names_and_namespaces():
             node_name = namespace + name if namespace.endswith('/') else namespace + '/' + name
 
-            for topic_name, topic_type in \
+            for topic_name, publisher_type in \
                     self._node.get_publisher_names_and_types_by_node(name, namespace):
                 publishers[topic_name].append(node_name)
+                publisher_topic_types[topic_name][node_name].append(publisher_type)
                 publisher_topic_names.add(topic_name)
 
-            for topic_name, topic_type in \
+            for topic_name, publisher_type in \
                     self._node.get_subscriber_names_and_types_by_node(name, namespace):
                 subscriptions[topic_name].append(node_name)
+                subscriber_topic_types[topic_name][node_name].append(publisher_type)
                 subscriber_topic_names.add(topic_name)
 
             for service_name, service_type in \
@@ -341,6 +350,13 @@ class Graph(object):
                         for sub_qos in sub_qos_list
                     ):
                         self.topic_with_qos_incompatibility[topic][pub_node].append(sub_node)
+
+        for topic_name, topic_subscribers in subscriber_topic_types.items():
+            for subscriber_name, subscriber_types in topic_subscribers.items():
+                for subscriber_type in subscriber_types:
+                    for publisher_name, publisher_types in publisher_topic_types[topic_name].items():
+                        if subscriber_type not in publisher_types:
+                            self.topic_with_type_incompatibility[topic_name][publisher_name].append(subscriber_name)
 
         pubs = list(publishers.items())
         subs = list(subscriptions.items())

--- a/src/rqt_graph/rosgraph2_impl.py
+++ b/src/rqt_graph/rosgraph2_impl.py
@@ -275,7 +275,7 @@ class Graph(object):
         self.topic_with_qos_incompatibility = defaultdict(lambda: defaultdict(list))
 
         # same type as topic_with_qos_incompatibility
-        self.topic_with_type_incompatibility : dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
+        self.topic_with_type_incompatibility = defaultdict(lambda: defaultdict(list))
 
     def set_node_stale(self, stale_secs):
         """
@@ -352,11 +352,15 @@ class Graph(object):
                         self.topic_with_qos_incompatibility[topic][pub_node].append(sub_node)
 
         for topic_name, topic_subscribers in subscriber_topic_types.items():
-            for subscriber_name, subscriber_types in topic_subscribers.items():
+            for subscriber, subscriber_types in topic_subscribers.items():
                 for subscriber_type in subscriber_types:
-                    for publisher_name, publisher_types in publisher_topic_types[topic_name].items():
+                    for publisher, publisher_types in publisher_topic_types[
+                        topic_name
+                    ].items():
                         if subscriber_type not in publisher_types:
-                            self.topic_with_type_incompatibility[topic_name][publisher_name].append(subscriber_name)
+                            self.topic_with_type_incompatibility[topic_name][
+                                publisher
+                            ].append(subscriber)
 
         pubs = list(publishers.items())
         subs = list(subscriptions.items())

--- a/src/rqt_graph/rosgraph2_impl.py
+++ b/src/rqt_graph/rosgraph2_impl.py
@@ -314,10 +314,10 @@ class Graph(object):
                 publisher_topic_types[topic_name][node_name].append(publisher_type)
                 publisher_topic_names.add(topic_name)
 
-            for topic_name, publisher_type in \
+            for topic_name, subscriber_type in \
                     self._node.get_subscriber_names_and_types_by_node(name, namespace):
                 subscriptions[topic_name].append(node_name)
-                subscriber_topic_types[topic_name][node_name].append(publisher_type)
+                subscriber_topic_types[topic_name][node_name].append(subscriber_type)
                 subscriber_topic_names.add(topic_name)
 
             for service_name, service_type in \


### PR DESCRIPTION
This adds a warning to topics with matching name but incompatible type in the same way as is already done for QOS incompatibilities.

Relates to #100 
