### PR TITLE
Fix: broken dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,6 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python_qt_binding</exec_depend>
-  <exec_depend>python3-pyqt6.qtsvg</exec_depend>
   <exec_depend version_gte="1.1.2">qt_dotgraph</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rqt_gui</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python_qt_binding</exec_depend>
+  <exec_depend>python3-qt-bindings</exec_depend>
   <exec_depend version_gte="1.1.2">qt_dotgraph</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rqt_gui</exec_depend>


### PR DESCRIPTION
@ahcorde 
My rolling source build was broken by https://github.com/ros-visualization/rqt_graph/pull/114
rosdep install: `rqt_graph: Cannot locate rosdep definition for [python3-pyqt6.qtsvg]`

Looking at the [python rosdep sources](https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml), `python3-pyqt6.qtsvg` is an os-specific package which is included under `python3-qt-bindings` where necessary. It is a bit confusing having `python3-qt-bindings` and also a ros package [`python_qt_binding`](https://github.com/ros-visualization/python_qt_binding), which does not support qt6.

node_graph works as usual after the fix:
<img width="599" height="489" alt="image" src="https://github.com/user-attachments/assets/c48f1170-616e-4be2-b625-fe4c85400a67" />

<img width="547" height="467" alt="image" src="https://github.com/user-attachments/assets/a37f4ac8-b13f-46a3-a5bb-6d64ed695fd3" />
